### PR TITLE
 feat(cli): Add projectDir flag

### DIFF
--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -16,6 +16,9 @@ export class Project extends Command {
       char: 'm',
       exclusive: ['json'],
     }),
+    projectDir: flags.string({
+      char: 'p',
+    }),
     json: flags.boolean({
       default: false,
       char: 'j',
@@ -33,6 +36,7 @@ export class Project extends Command {
     const docs = TyDoc.fromProject({
       entrypoints: argv,
       readSettingsFromJSON: true,
+      prjDir: flags.projectDir ?? process.cwd(),
     })
 
     if (flags.json) {

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -18,6 +18,7 @@ export class Project extends Command {
     }),
     projectDir: flags.string({
       char: 'p',
+      helpValue: './projects/my-awesome-project',
     }),
     json: flags.boolean({
       default: false,

--- a/src/lib/extractor/extract.ts
+++ b/src/lib/extractor/extract.ts
@@ -171,7 +171,8 @@ export function fromProject(opts: Options): Doc.DocPackage {
   const diagnostics = project.getPreEmitDiagnostics()
   if (diagnostics.length) {
     const message = project.formatDiagnosticsWithColorAndContext(diagnostics)
-    // throw new Error(message)
+    // TODO It would be nice to have a --force to not throw on errors here
+    throw new Error(message)
   }
 
   // If the project is empty dont' bother trying to extract docs

--- a/src/lib/extractor/extract.ts
+++ b/src/lib/extractor/extract.ts
@@ -83,12 +83,6 @@ function readSettingsFromPackage(): Partial<Doc.Settings> {
  * exports will be considered part of the API.
  */
 export function fromProject(opts: Options): Doc.DocPackage {
-  const project =
-    opts.project ??
-    new tsm.Project({
-      tsConfigFilePath: path.join(process.cwd(), 'tsconfig.json'),
-    })
-
   // Wherever the user's package.json is. We assume for now that this tool is
   // running from project root.
   // todo there seems to be no way to get project dir from project instance??
@@ -101,6 +95,15 @@ export function fromProject(opts: Options): Doc.DocPackage {
     prjDir = process.cwd()
     debug('prjDir set to %s -- taken from current working directory', prjDir)
   }
+  const project =
+    opts.project ??
+    new tsm.Project({
+      tsConfigFilePath: path.join(prjDir, 'tsconfig.json'),
+      compilerOptions: {
+        skipLibCheck: true,
+        skipDefaultLibCheck: true
+      },
+    })
 
   // Find the source dir
   //
@@ -168,7 +171,7 @@ export function fromProject(opts: Options): Doc.DocPackage {
   const diagnostics = project.getPreEmitDiagnostics()
   if (diagnostics.length) {
     const message = project.formatDiagnosticsWithColorAndContext(diagnostics)
-    throw new Error(message)
+    // throw new Error(message)
   }
 
   // If the project is empty dont' bother trying to extract docs

--- a/src/lib/renderers/markdown.ts
+++ b/src/lib/renderers/markdown.ts
@@ -1,4 +1,4 @@
-import * as Debug from 'Debug'
+import * as Debug from 'debug'
 import * as Prettier from 'prettier'
 import * as Doc from '../extractor/doc'
 import * as MD from '../lib/markdown'


### PR DESCRIPTION
Allows you to point the cli to a specific project 
```
USAGE
  $ tydoc project FILEPATH

ARGUMENTS
  FILEPATH  Entrypoint(s) into the package

OPTIONS
  -j, --json
  -m, --markdown
  -p, --projectDir=./projects/my-awesome-project

  --flat-terms-section                            For use with markdown rendering. Whether or not the API terms section should have a title and nest its term entries under it. If false, term 
                          
```